### PR TITLE
NOSTORY: Upgrade to 0.14/2.0 cloudflare/dns/record

### DIFF
--- a/modules/cloudflare/dns/README.md
+++ b/modules/cloudflare/dns/README.md
@@ -2,15 +2,30 @@
 
 For these examples the values of the variables are stored on **hlc** files.
 
-### DNS Record:
+This module is compatible with Terraform 14.x or higher.
+### DNS Record example for 2.0 provider:
 
 ```
-module "cfRecord_1" {
-  source = "<LOCAL_PATH>"
-  cloudflare_zone = "${var.cloudflare_zone}"
-  name = "${var.cloudflare_fqdn_1}"
-  value = "${var.cloudflare_s3_website}"
+module "clouflare_record" {
+  source = "./record/"
+  zone_id = "123542etdfl345..."
+  name = "record.boldlink.io"
+  value = "lb.read-api.prd.boldlink.io"
   type = "CNAME"
-  ttl = "3600"
+}
+
+provider "cloudflare" {
+# Authentication - consider using variables so you don't hardcode it on your code
+  email      = "example@boldlink.io"
+  api_key    = "23wer4665..."
+  account_id = "45ljlk345n3453..."
+}
+
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
 }
 ```

--- a/modules/cloudflare/dns/record/main.tf
+++ b/modules/cloudflare/dns/record/main.tf
@@ -1,9 +1,8 @@
-
 resource "cloudflare_record" "main" {
-  domain = "${var.cloudflare_zone}"
-  name   = "${var.name}"
-  value  = "${var.value}"
-  type   = "${var.type}"
-  ttl    = "${var.ttl}"
-  proxied = "${var.proxied}"
+  zone_id = var.zone_id
+  name    = var.name
+  value   = var.value
+  type    = var.type
+  ttl     = var.ttl
+  proxied = var.proxied
 }

--- a/modules/cloudflare/dns/record/outputs.tf
+++ b/modules/cloudflare/dns/record/outputs.tf
@@ -1,26 +1,12 @@
-output "id" {
-  value = "${cloudflare_record.main.id}"
-}
+output "id" { value = cloudflare_record.main.id }
 
-output "hostname" {
-  value = "${cloudflare_record.main.hostname}"
-}
+output "hostname" { value = cloudflare_record.main.hostname }
 
-output "created_on" {
-  value = "${cloudflare_record.main.created_on}"
-}
+output "created_on" { value = cloudflare_record.main.created_on }
 
-output "modified_on" {
-  value = "${cloudflare_record.main.modified_on}"
-}
+output "modified_on" { value = cloudflare_record.main.modified_on }
 
-output "metadata" {
-  value = "${cloudflare_record.main.metadata}"
-}
+output "metadata" { value = cloudflare_record.main.metadata }
 
-output "zone_id" {
-  value = "${cloudflare_record.main.zone_id}"
-}
-
-
+output "zone_id" { value = cloudflare_record.main.zone_id }
 

--- a/modules/cloudflare/dns/record/variables.tf
+++ b/modules/cloudflare/dns/record/variables.tf
@@ -1,23 +1,11 @@
-variable "cloudflare_zone" {
-  default = ""
-}
+variable "zone_id" {}
 
-variable "name" {
-  default = ""
-}
+variable "name" {}
 
-variable "value" {
-  default = ""
-}
+variable "value" {}
 
-variable "type" {
-  default = ""
-}
+variable "type" { default = "CNAME" }
 
-variable "ttl" {
-  default = ""
-}
+variable "ttl" { default = 3600 }
 
-variable "proxied" {
-  default = true
-}
+variable "proxied" { default = false }

--- a/modules/cloudflare/dns/record/versions.tf
+++ b/modules/cloudflare/dns/record/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+  required_version = ">= 0.14"
+}

--- a/modules/cloudflare/provider/provider_cloudflare.tf
+++ b/modules/cloudflare/provider/provider_cloudflare.tf
@@ -1,0 +1,15 @@
+provider "cloudflare" {
+  version = "=> x.x.x"
+  email      = ""
+  api_key    = ""
+  account_id = ""
+}
+
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    #   version = "=> x.x.x"
+    }
+  }
+}


### PR DESCRIPTION
Convert the Cloudflare module for DNS/Record to Terraform 0.14+ and provider 2.0